### PR TITLE
Possible fix for timeout issue

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -86,7 +86,8 @@ export const config = {
           '--dns-prefetch-disable',
           '--disable-background-networking',
           '--disable-remote-fonts',
-          '--ignore-certificate-errors'
+          '--ignore-certificate-errors',
+          '--host-resolver-rules=MAP www.googletagmanager.com 127.0.0.1'
         ]
       }
     }


### PR DESCRIPTION
Adds  '--host-resolver-rules=MAP www.googletagmanager.com 127.0.0.1' arg to chrome. This effectively remaps calls to google tag manager to localhost so they should fail instantly rather than timing out